### PR TITLE
fixed link formats for AsciiDoc

### DIFF
--- a/CODE_OF_CONDUCT.asciidoc
+++ b/CODE_OF_CONDUCT.asciidoc
@@ -39,11 +39,11 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 == Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <icsddevonfwsupport.apps2@capgemini.com>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at icsddevonfwsupport.apps2@capgemini.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 == Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+This Code of Conduct is adapted from the https://www.contributor-covenant.org[Contributor Covenant], version 1.4,
 available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>


### PR DESCRIPTION
Removed `< >` in direct link and used `url[text]` link format for named link.