### PR TITLE
Update en-devonfw.dict

### DIFF
--- a/en-devonfw.dict
+++ b/en-devonfw.dict
@@ -436,6 +436,7 @@ OCI
 OLTP
 OmniSharp
 OOP
+openapi
 OpenAPI
 OpenID
 OpenJDK


### PR DESCRIPTION
Cannot change openapi to OpenAPI in reference. So adding word to dict.